### PR TITLE
Should set CORS headers on cross-domain requests.

### DIFF
--- a/dist/request.js
+++ b/dist/request.js
@@ -9,6 +9,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 var http = require('superagent');
 var qs = require('qs').stringify;
 var merge = require('deepmerge');
+var isBrowser = require('is-browser');
 
 var Request = (function () {
   function Request(method, url, token) {
@@ -106,7 +107,9 @@ var Request = (function () {
     key: 'exec',
     value: function exec(cb) {
       var u = getURL(this.url, this.key, this.queryObj);
-      http(this.method.toUpperCase(), u).set('Authorization', 'Bearer ' + this.token).end(cb);
+      var req = http(this.method.toUpperCase(), u).set('Authorization', 'Bearer ' + this.token);
+      if (isBrowser) req.withCredentials();
+      req.end(cb);
       this.key = undefined;
     }
   }]);

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
   "main": "dist/retsly.js",
   "license": "MIT",
   "dependencies": {
-    "superagent": "^1.2.0",
+    "deepmerge": "^0.2.7",
+    "is-browser": "^2.0.1",
     "qs": "2.3.3",
-    "deepmerge": "^0.2.7"
+    "superagent": "^1.2.0"
   },
-  "devDependencies" : {
+  "devDependencies": {
     "mocha": "^2.2.4",
     "babel": "^5.1.13"
   },

--- a/src/request.js
+++ b/src/request.js
@@ -1,6 +1,7 @@
 let http = require('superagent');
 let qs = require('qs').stringify;
 let merge = require('deepmerge');
+let isBrowser = require('is-browser');
 
 class Request {
   constructor(method, url, token, query = {}) {
@@ -78,9 +79,12 @@ class Request {
 
   exec(cb) {
     let u = getURL(this.url, this.key, this.queryObj);
-    http(this.method.toUpperCase(), u)
-      .set('Authorization', 'Bearer ' + this.token)
-      .end(cb);
+    let req = http(this.method.toUpperCase(), u)
+      .set('Authorization', 'Bearer ' + this.token);
+
+    if(isBrowser) req.withCredentials();
+
+    req.end(cb);
     this.key = undefined;
   }
 }


### PR DESCRIPTION
This should be as simple as adding the npm package ```is-browser```, checking if the sdk is being used in-browser, and, if so, adding ```.withCredentials()``` to the ```superagent``` request.