### PR TITLE
Pass (err, response.body) to callback

### DIFF
--- a/dist/request.js
+++ b/dist/request.js
@@ -109,7 +109,7 @@ var Request = (function () {
       var u = getURL(this.url, this.key, this.queryObj);
       var req = http(this.method.toUpperCase(), u).set('Authorization', 'Bearer ' + this.token);
       if (isBrowser) req.withCredentials();
-      req.end(cb);
+      req.end(function(err, response) { return cb(err, response.body); });
       this.key = undefined;
     }
   }]);

--- a/src/request.js
+++ b/src/request.js
@@ -84,7 +84,11 @@ class Request {
 
     if(isBrowser) req.withCredentials();
 
-    req.end(cb);
+    // return the response body to the callback
+    req.end(function(err, response) {
+      return cb(err, response.body);
+    });
+
     this.key = undefined;
   }
 }


### PR DESCRIPTION
Currently, we get the raw response being sent back to the sdk callback. Response.body is what implementers will expect.

TODO:
- [x] Solve.